### PR TITLE
Add edge and corner orientation reducer

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ description: Please see the README on GitHub at <https://github.com/jradtilbrook
 dependencies:
   - base >= 4.7 && < 5
   - hlint
+  - vector
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -46,3 +46,4 @@ tests:
       - -with-rtsopts=-N
     dependencies:
       - rubiks
+      - hspec

--- a/src/Cubie/Heuristics/StateOne.hs
+++ b/src/Cubie/Heuristics/StateOne.hs
@@ -1,0 +1,9 @@
+module Cubie.Heuristics.StateOne
+( binaryFold
+) where
+
+{-
+ - This is used as a reducer for the edge orientation vector.
+ - It treats the vector as a binary number and converts it to decimal using little-endian.
+ -}
+binaryFold carry index value = carry + value * 2 ^ index

--- a/src/Cubie/Heuristics/StateTwo.hs
+++ b/src/Cubie/Heuristics/StateTwo.hs
@@ -1,0 +1,9 @@
+module Cubie.Heuristics.StateTwo
+( ternaryFold
+) where
+
+{-
+ - This is used as a reducer for the corner orientation vector.
+ - It treats the vector as a ternary number and converts it to decimal using little-endian.
+ -}
+ternaryFold carry index value = carry + (value + 1) * 3 ^ index

--- a/test/Cubie/Heuristics/StateOneSpec.hs
+++ b/test/Cubie/Heuristics/StateOneSpec.hs
@@ -1,0 +1,20 @@
+module Cubie.Heuristics.StateOneSpec (spec) where
+
+import Test.Hspec
+import Cubie.Heuristics.StateOne
+import Data.Vector.Unboxed as V
+
+spec :: Spec
+spec = describe "binaryFold" $ do
+    it "[0] equals 0" $
+        V.ifoldl binaryFold 0 (V.fromList [0 :: Int]) `shouldBe` 0
+    it "[1] equals 1" $
+        V.ifoldl binaryFold 0 (V.fromList [1 :: Int]) `shouldBe` 1
+    it "[0, 1] equals 2" $
+        V.ifoldl binaryFold 0 (V.fromList [0, 1 :: Int]) `shouldBe` 2
+    it "[1, 1, 0, 1] equals 11" $
+        V.ifoldl binaryFold 0 (V.fromList [1, 1, 0, 1 :: Int]) `shouldBe` 11
+    it "[1, 0, 1, 1, 0, 1] equals 45" $
+        V.ifoldl binaryFold 0 (V.fromList [1, 0, 1, 1, 0, 1 :: Int]) `shouldBe` 45
+    it "[1, 1, 1, 1, 1, 1, 1] equals 127" $
+        V.ifoldl binaryFold 0 (V.fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 127

--- a/test/Cubie/Heuristics/StateOneSpec.hs
+++ b/test/Cubie/Heuristics/StateOneSpec.hs
@@ -2,19 +2,19 @@ module Cubie.Heuristics.StateOneSpec (spec) where
 
 import Test.Hspec
 import Cubie.Heuristics.StateOne
-import Data.Vector.Unboxed as V
+import Data.Vector.Unboxed (fromList, ifoldl)
 
 spec :: Spec
 spec = describe "binaryFold" $ do
     it "[0] equals 0" $
-        V.ifoldl binaryFold 0 (V.fromList [0 :: Int]) `shouldBe` 0
+        ifoldl binaryFold 0 (fromList [0 :: Int]) `shouldBe` 0
     it "[1] equals 1" $
-        V.ifoldl binaryFold 0 (V.fromList [1 :: Int]) `shouldBe` 1
+        ifoldl binaryFold 0 (fromList [1 :: Int]) `shouldBe` 1
     it "[0, 1] equals 2" $
-        V.ifoldl binaryFold 0 (V.fromList [0, 1 :: Int]) `shouldBe` 2
+        ifoldl binaryFold 0 (fromList [0, 1 :: Int]) `shouldBe` 2
     it "[1, 1, 0, 1] equals 11" $
-        V.ifoldl binaryFold 0 (V.fromList [1, 1, 0, 1 :: Int]) `shouldBe` 11
+        ifoldl binaryFold 0 (fromList [1, 1, 0, 1 :: Int]) `shouldBe` 11
     it "[1, 0, 1, 1, 0, 1] equals 45" $
-        V.ifoldl binaryFold 0 (V.fromList [1, 0, 1, 1, 0, 1 :: Int]) `shouldBe` 45
+        ifoldl binaryFold 0 (fromList [1, 0, 1, 1, 0, 1 :: Int]) `shouldBe` 45
     it "[1, 1, 1, 1, 1, 1, 1] equals 127" $
-        V.ifoldl binaryFold 0 (V.fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 127
+        ifoldl binaryFold 0 (fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 127

--- a/test/Cubie/Heuristics/StateTwoSpec.hs
+++ b/test/Cubie/Heuristics/StateTwoSpec.hs
@@ -7,16 +7,16 @@ import Data.Vector.Unboxed as V
 spec :: Spec
 spec = describe "ternaryFold" $ do
     it "[-1] equals 0" $
-        V.ifoldl ternaryFold 0 (V.fromList [-1 :: Int]) `shouldBe` 0
+        ifoldl ternaryFold 0 (fromList [-1 :: Int]) `shouldBe` 0
     it "[0] equals 1" $
-        V.ifoldl ternaryFold 0 (V.fromList [0 :: Int]) `shouldBe` 1
+        ifoldl ternaryFold 0 (fromList [0 :: Int]) `shouldBe` 1
     it "[1] equals 2" $
-        V.ifoldl ternaryFold 0 (V.fromList [1 :: Int]) `shouldBe` 2
+        ifoldl ternaryFold 0 (fromList [1 :: Int]) `shouldBe` 2
     it "[0, 1] equals 7" $
-        V.ifoldl ternaryFold 0 (V.fromList [0, 1 :: Int]) `shouldBe` 7
+        ifoldl ternaryFold 0 (fromList [0, 1 :: Int]) `shouldBe` 7
     it "[1, -1, 0, 1] equals 65" $
-        V.ifoldl ternaryFold 0 (V.fromList [1, -1, 0, 1 :: Int]) `shouldBe` 65
+        ifoldl ternaryFold 0 (fromList [1, -1, 0, 1 :: Int]) `shouldBe` 65
     it "[1, 0, 1, 1, 0, -1] equals 158" $
-        V.ifoldl ternaryFold 0 (V.fromList [1, 0, 1, 1, 0, -1 :: Int]) `shouldBe` 158
+        ifoldl ternaryFold 0 (fromList [1, 0, 1, 1, 0, -1 :: Int]) `shouldBe` 158
     it "[1, 1, 1, 1, 1, 1, 1] equals 2186" $
-        V.ifoldl ternaryFold 0 (V.fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 2186
+        ifoldl ternaryFold 0 (fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 2186

--- a/test/Cubie/Heuristics/StateTwoSpec.hs
+++ b/test/Cubie/Heuristics/StateTwoSpec.hs
@@ -1,0 +1,22 @@
+module Cubie.Heuristics.StateTwoSpec (spec) where
+
+import Test.Hspec
+import Cubie.Heuristics.StateTwo
+import Data.Vector.Unboxed as V
+
+spec :: Spec
+spec = describe "ternaryFold" $ do
+    it "[-1] equals 0" $
+        V.ifoldl ternaryFold 0 (V.fromList [-1 :: Int]) `shouldBe` 0
+    it "[0] equals 1" $
+        V.ifoldl ternaryFold 0 (V.fromList [0 :: Int]) `shouldBe` 1
+    it "[1] equals 2" $
+        V.ifoldl ternaryFold 0 (V.fromList [1 :: Int]) `shouldBe` 2
+    it "[0, 1] equals 7" $
+        V.ifoldl ternaryFold 0 (V.fromList [0, 1 :: Int]) `shouldBe` 7
+    it "[1, -1, 0, 1] equals 65" $
+        V.ifoldl ternaryFold 0 (V.fromList [1, -1, 0, 1 :: Int]) `shouldBe` 65
+    it "[1, 0, 1, 1, 0, -1] equals 158" $
+        V.ifoldl ternaryFold 0 (V.fromList [1, 0, 1, 1, 0, -1 :: Int]) `shouldBe` 158
+    it "[1, 1, 1, 1, 1, 1, 1] equals 2186" $
+        V.ifoldl ternaryFold 0 (V.fromList [1, 1, 1, 1, 1, 1, 1 :: Int]) `shouldBe` 2186

--- a/test/Cubie/Heuristics/StateTwoSpec.hs
+++ b/test/Cubie/Heuristics/StateTwoSpec.hs
@@ -2,7 +2,7 @@ module Cubie.Heuristics.StateTwoSpec (spec) where
 
 import Test.Hspec
 import Cubie.Heuristics.StateTwo
-import Data.Vector.Unboxed as V
+import Data.Vector.Unboxed (fromList, ifoldl)
 
 spec :: Spec
 spec = describe "ternaryFold" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,6 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+
+{-
+ - The line above instructs GHC to invoke hspec-discover as a pre-processor.
+ - The pre-processor scans for Spec files to run tests from.
+ -}


### PR DESCRIPTION
This closes #4 and closes #5. It adds very simple reducers that can be used with the `ifoldl` function from the Vector package.

This should be all that is needed to compute and work with the heuristic table needed for the first part of solving the cube. The later steps will likely need more functions but they can be added when we figure out exactly what is needed.